### PR TITLE
Fixing an issue where the action would show a flickering vertical line.

### DIFF
--- a/BGTableViewRowActionWithImage.m
+++ b/BGTableViewRowActionWithImage.m
@@ -83,7 +83,7 @@
     
     CGFloat contentWidth=[titleSpaceString boundingRectWithSize:CGSizeMake(MAXFLOAT, cellHeight) options:NSStringDrawingUsesLineFragmentOrigin attributes:@{ NSFontAttributeName: [UIFont systemFontOfSize:fontSize_iOS8AndUpDefault] } context:nil].size.width;
     
-    CGSize frameGuess=CGSizeMake((margin_horizontal_iOS8AndUp*2)+contentWidth, cellHeight);
+    CGSize frameGuess=CGSizeMake(ceilf((margin_horizontal_iOS8AndUp*2)+contentWidth), ceilf(cellHeight));
     
     CGSize tripleFrame=CGSizeMake(frameGuess.width*3.0f, frameGuess.height*3.0f);
     


### PR DESCRIPTION
Fixing an issue where the action would show a flickering vertical line. This happens because the width calculation results in a floating point. We should round it so iOS would render it properly.